### PR TITLE
Resolves #250 Added a means to disable errors for missing resource definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ Devour takes an object as the initializer. The following options are available:
 
 **trailingSlash**: An optional object to use trailing slashes on resource and/or collection urls (defaults to false), `new JsonApi({apiUrl: 'http://your-api-here.com', trailingSlash: {resource: false, collection: true})`
 
+### Errors
+
+Devour may throw an error when a model definition is not yet defined in Devour's model directory. To disable such errors, use the `disableErrorsForMissingResourceDefinitions` flag like so:
+
+```js
+const jsonApi = new JsonApi({
+  apiUrl: 'http://your-api-here.com',
+  disableErrorsForMissingResourceDefinitions: true
+})
+```
+
 ### Relationships
 
 Devour comes stock with an easy way of defining relationships which can be included when hitting your API.

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,8 @@ class JsonApi {
       resetBuilderOnCall: true,
       auth: {},
       bearer: null,
-      trailingSlash: { collection: false, resource: false }
+      trailingSlash: { collection: false, resource: false },
+      disableErrorsForMissingResourceDefinitions: false
     }
 
     const deprecatedConstructors = (args) => {
@@ -93,6 +94,7 @@ class JsonApi {
     this.auth = options.auth
     this.apiUrl = options.apiUrl
     this.bearer = options.bearer
+    this.disableErrorsForMissingResourceDefinitions = options.disableErrorsForMissingResourceDefinitions
     this.models = {}
     this.deserialize = deserialize
     this.serialize = serialize
@@ -417,9 +419,15 @@ class JsonApi {
 
   modelFor (modelName) {
     if (!this.models[modelName]) {
-      throw new Error(`API resource definition for model "${modelName}" not found. Available models: ${Object.keys(this.models)}`)
+      if (!this.disableErrorsForMissingResourceDefinitions) {
+        throw new Error(`API resource definition for model "${modelName}" not found. Available models: ${Object.keys(this.models)}`)
+      }
+      Logger.error(`API resource definition for model "${modelName}" not found. Available models: ${Object.keys(this.models)}`)
+      return {
+        attributes: {},
+        options: {}
+      }
     }
-
     return this.models[modelName]
   }
 

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -911,6 +911,14 @@ describe('JsonApi', () => {
     it.skip('should throw an error while attempting to access undefined model', function (done) {
       expect(function () { jsonApi.findAll('derp').then(done).catch(done) }).to.throwException(/API resource definition for model/)
     })
+
+    it('should not throw any errors accessing undefined models while the disableErrorsForMissingResourceDefinitions flag is enabled.', function () {
+      jsonApi.disableErrorsForMissingResourceDefinitions = true
+      expect(jsonApi.modelFor('derp')).to.be.an('object').and.to.eql({
+        attributes: {},
+        options: {}
+      })
+    })
   })
 
   describe('Complex API calls', () => {


### PR DESCRIPTION
## Screenshot
N/A

## What Changed & Why
Introduced a flag `disableErrorsForMissingResourceDefinitions` to effectively disable the error _'API resource definition for model "XWY" not found'_. Instead of throwing the error though, we are invoking the Logger's error method to let users know they should fix it.

Since invokers of the `modelFor` method expect a model, we are returning an empty model structure which has proved effective in our tests.

## Testing
Just run the tests.

## Documentation
Updated the README file with instructions.
